### PR TITLE
feat: add general styles to the plp in all views

### DIFF
--- a/store/blocks/desktop/components/product_list_page/top_plp.jsonc
+++ b/store/blocks/desktop/components/product_list_page/top_plp.jsonc
@@ -2,10 +2,233 @@
     "flex-layout.row#plp__top--section": {
         "title": "Top plp section container",
         "children": [
-            "flex-layout.row#department__breadcrumb",
-            "flex-layout.col#plp__modal--filter",
-            "gallery-layout-switcher#desktop__gallery--switcher"
+            "flex-layout.col#plp__top--container"
         ]
+    },
+    "flex-layout.col#plp__top--container": {
+        "title": "Plp top container",
+        "children": [
+            "flex-layout.row#plp__first--head_section",
+            "flex-layout.row#plp__second--head_section"
+        ],
+        "props": {
+            "blockClass": "plp__top--container"
+        }
+    },
+    "flex-layout.row#plp__first--head_section": {
+        "title": "Plp first head section",
+        "children": [
+            "flex-layout.col#plp__header--breadcrumb",
+            "flex-layout.col#plp__header--title"
+        ],
+        "props": {
+            "blockClass": "plp__first--head_section"
+        }
+    },
+    "flex-layout.col#plp__header--breadcrumb": {
+        "title": "Plp header breadcrumb container",
+        "children": [
+            "breadcrumb.search#plp__header--breadcrumb"
+        ],
+        "props": {
+            "blockClass": "plp__header--breadcrumb"
+        }
+    },
+    "breadcrumb.search#plp__header--breadcrumb": {
+        "title": "Plp header breadcrumb",
+        "props": {
+            "blockClass": "plp__header--breadcrumb"
+        }
+    },
+    "flex-layout.col#plp__header--title": {
+        "title": "Plp header title container",
+        "children": [
+            "flex-layout.row#plp__header--title_compelement",
+            "flex-layout.row#plp__header--title_full"
+        ],
+        "props": {
+            "blockClass": "plp__header--title"
+        }
+    },
+    "flex-layout.row#plp__header--title_compelement": {
+        "title": "Plp header title compelement container",
+        "children": [
+            "rich-text#desktop__department--title"
+        ],
+        "props": {
+            "blockClass": "plp__header--title_compelement"
+        }
+    },
+    "rich-text#desktop__department--title": {
+        "title": "Departmen title complement text",
+        "props": {
+            "text": "Resultado de la búsqueda de",
+            "blockClass": "desktop__department--title"
+        }
+    },
+    "flex-layout.row#plp__header--title_full": {
+        "title": "Plp header title compelement container",
+        "children": [
+            "search-title.v2#desktop__search--title"
+        ],
+        "props": {
+            "blockClass": "plp__header--title_full"
+        }
+    },
+    "search-title.v2#desktop__search--title": {
+        "title": "Search result title",
+        "props": {
+            "blockClass": "desktop__search--title"
+        }
+    },
+
+    "flex-layout.row#plp__second--head_section": {
+        "title": "Plp second head section container",
+        "children": [
+            "flex-layout.col#plp__header--search",
+            "flex-layout.col#plp__header--filter",
+            "flex-layout.col#plp__header--switcher",
+            "flex-layout.col#plp__header--pagination"
+        ]
+    },
+
+
+    "flex-layout.col#plp__header--search": {
+        "title": "Plp header filter container",
+        "children": [
+            "flex-layout.row#plp__header--search"
+        ], 
+        "props": {
+            "blockClass": "plp__header--search"
+        }
+    },
+    "flex-layout.row#plp__header--search": {
+        "title": "desktop plp switcher",
+        "children": [
+            "drawer#header__plp--search"
+        ],
+        "props": {
+            "blockClass": "plp__header--search"
+        }
+    },
+    "drawer#header__plp--search": {
+        "title": "header plp filters",
+        "blocks": [
+            "drawer-trigger#global__text--search"
+        ],
+        "props": {
+            "slideDirection": "horizontal",
+            "blockClass": "header__plp--search"
+        },
+        "children": [
+            "filter-navigator.v3#header__plp--search"
+        ]
+    },
+    "filter-navigator.v3#header__plp--search": {
+        "title": "Filter plp header",
+        "props": {
+            "blockClass": "header__plp--search"
+        }
+    },
+    "drawer-trigger#global__text--search": {
+        "title": "Mobile text filters",
+        "children": [
+            "icon#global__search--icon",
+            "rich-text#plp__search--btn"
+        ],
+        "props": {
+            "blockClass": "global__text--search",
+            "isFullWidth": true,
+            "slideDirection": "vertical"
+        }
+    },
+    "rich-text#plp__search--btn": {
+        "title": "plp filters btn",
+        "props": {
+            "text": "Buscar en otras líneas",
+            "blockClass": "plp__search--btn"
+        }
+    },
+    "icon#global__search--icon": {
+        "title": "Filter icon",
+        "props": {
+            "id": "mpa-filter",
+            "size": 35,
+            "width": "20%",
+            "blockClass": "global__search--icon"
+        }
+    },
+
+
+
+
+    "flex-layout.col#plp__header--filter": {
+        "title": "Plp header filter container",
+        "children": [
+            "flex-layout.row#desktop__plp--filters"
+        ], 
+        "props": {
+            "blockClass": "plp__header--filter"
+        }
+    },
+    "flex-layout.row#desktop__plp--filters": {
+        "title": "desktop plp switcher",
+        "children": [
+            "drawer#header__plp--filters"
+        ],
+        "props": {
+            "blockClass": "plp__filters--desktop"
+        }
+    },
+    "drawer#header__plp--filters": {
+        "title": "header plp filters",
+        "blocks": [
+            "drawer-trigger#mobile__text--filters"
+        ],
+        "props": {
+            "slideDirection": "horizontal",
+            "blockClass": "header__plp--filters"
+        },
+        "children": [
+            "filter-navigator.v3"
+        ]
+    },
+    "drawer-trigger#mobile__text--filters": {
+        "title": "Mobile text filters",
+        "children": [
+            "icon#global__filter--icon",
+            "rich-text#plp__filters--btn"
+        ],
+        "props": {
+            "blockClass": "mobile__text--filters",
+            "isFullWidth": true,
+            "slideDirection": "vertical"
+        }
+    },
+    "rich-text#plp__filters--btn": {
+        "title": "plp filters btn",
+        "props": {
+            "text": "Filtrar y Ordenar",
+            "blockClass": "plp__filters--btn"
+        }
+    },
+    "icon#global__filter--icon": {
+        "title": "Filter icon",
+        "props": {
+            "id": "mpa-filter",
+            "size": 35,
+            "width": "20%",
+            "blockClass": "global__filter--icon"
+        }
+    },
+    "flex-layout.col#plp__header--switcher": {
+        "title": "Plp header switcher container",
+        "children": [
+            "gallery-layout-switcher#desktop__gallery--switcher"
+        ], 
+        "props": {
+            "blockClass": "plp__header--switcher"
+        }
     },
     "gallery-layout-switcher#desktop__gallery--switcher": {
         "title": "Gallery desktop switcher container",
@@ -69,67 +292,17 @@
             "text": "List"
         }
     },
-    "flex-layout.row#department__breadcrumb": {
-        "title": "Department breadcrumb container row",
+    "flex-layout.col#plp__header--pagination": {
+        "title": "Plp header pagination container",
         "children": [
-            "flex-layout.col#department__breadcrumb",
-            "flex-layout.row#departmen__title--container"
-        ],
+
+        ], 
         "props": {
-            "blockClass": "department__breadcrumb--row"
+            "blockClass": "plp__header--pagination"
         }
-    },
-    "flex-layout.col#department__breadcrumb": {
-        "title": "Department  breadcrumb container column",
-        "children": [
-            "breadcrumb.search"
-        ],
-        "props": {
-            "blockClass": "department__breadcrumb--col"
-        }
-    },
-    "flex-layout.row#departmen__title--container": {
-        "title": "Department title container",
-        "children": [
-            "flex-layout.col#department__title--complement",
-            "flex-layout.col#department__title"
-        ],
-        "props": {
-            "blockClass": "departmen__title--container"
-        }
-    },
-    "flex-layout.col#department__title--complement": {
-        "title": "Department title complement container",
-        "children": [
-            "rich-text#desktop__department--title"
-        ],
-        "props": {
-            "blockClass": "department__title--complement"
-        }
-    },
-    "rich-text#desktop__department--title": {
-        "title": "Departmen title complement text",
-        "props": {
-            "text": "Resultado de la búsqueda de",
-            "blockClass": "desktop__department--title"
-        }
-    },
-    "flex-layout.col#department__title": {
-        "title": "Department  breadcrumb container column",
-        "children": [
-            "search-title.v2#desktop__search--title"
-        ],
-        "props": {
-            "blockClass": "department__breadcrumb--col"
-        }
-    },
-    "search-title.v2#desktop__search--title": {
-        "title": "Search result title",
-        "props": {
-            "blockClass": "desktop__search--title"
-        }
-    },
-    "flex-layout.col#plp__modal--filter": {
+    }
+    
+    /* "flex-layout.col#plp__modal--filter": {
         "title": "Plp switcher",
         "children": [
             "flex-layout.row#desktop__plp--switcher",
@@ -147,55 +320,6 @@
         "props": {
             "blockClass": "desktop__plp--switcher"
         }
-    },
-    "flex-layout.row#desktop__plp--filters": {
-        "title": "desktop plp switcher",
-        "children": [
-            "drawer#header__plp--filters"
-        ],
-        "props": {
-            "blockClass": "plp__filters--desktop"
-        }
-    },
-    "drawer#header__plp--filters": {
-        "title": "header plp filters",
-        "blocks": [
-            "drawer-trigger#mobile__text--filters"
-        ],
-        "props": {
-            "slideDirection": "horizontal",
-            "blockClass": "header__plp--filters"
-        },
-        "children": [
-            "filter-navigator.v3"
-        ]
-    },
-    "drawer-trigger#mobile__text--filters": {
-        "title": "Mobile text filters",
-        "children": [
-            "icon#global__filter--icon",
-            "rich-text#plp__filters--btn"
-        ],
-        "props": {
-            "blockClass": "mobile__text--filters",
-            "isFullWidth": true,
-            "slideDirection": "vertical"
-        }
-    },
-    "rich-text#plp__filters--btn": {
-        "title": "plp filters btn",
-        "props": {
-            "text": "Filtrar y Ordenar",
-            "blockClass": "plp__filters--btn"
-        }
-    },
-    "icon#global__filter--icon": {
-        "title": "Filter icon",
-        "props": {
-            "id": "mpa-filter",
-            "size": 35,
-            "width": "20%",
-            "blockClass": "global__filter--icon"
-        }
-    }
+    } */
+    
 }

--- a/store/blocks/mobile/components/department/department.jsonc
+++ b/store/blocks/mobile/components/department/department.jsonc
@@ -2,7 +2,7 @@
     "search-result-layout.mobile#mobile__global--search_result":{
         "title":"Search result for mobile view",
         "children":[
-            "flex-layout.row#department__breadcrumb",
+           /*  "flex-layout.col#plp__header--breadcrumb", */
             "flex-layout.row#department__results"
         ]
     }

--- a/styles/css/desktop/plp/vtex.flex-layout.css
+++ b/styles/css/desktop/plp/vtex.flex-layout.css
@@ -2,11 +2,11 @@
     display       : flex;
     flex-direction: row;
     align-items   : center;
-    gap           : 7.2rem;
+    gap           : 7.1rem;
     font-weight   : bold;
-    transform     : translate(126px, 10px);
-    margin-top    : 2rem;
-}
+    transform     : translate(155px, -30px);
+/*     margin-top    : 2rem;
+ */}
 
 .flexRow--departmen__title--container {
     transform: translate(130px, 10px);

--- a/styles/css/desktop/plp/vtex.rich-text.css
+++ b/styles/css/desktop/plp/vtex.rich-text.css
@@ -1,6 +1,6 @@
 .paragraph--desktop__department--title {
     font-size     : 13px;
-    letter-spacing: .3px;
+    letter-spacing: .5px;
     text-transform: uppercase;
     white-space   : nowrap;
     font-weight   : bold;

--- a/styles/css/desktop/plp/vtex.search-result.css
+++ b/styles/css/desktop/plp/vtex.search-result.css
@@ -16,10 +16,6 @@
     margin-left   : 17rem;
 }
 
-.galleryLayoutSwitcher--desktop__gallery--switcher {
-    transform: translate(10px, 32px);
-}
-
 .filtersWrapper--search__filter--navigator {
     width          : 19rem;
     margin-left    : 3rem;

--- a/styles/css/desktop/plp/vtex.store-drawer.css
+++ b/styles/css/desktop/plp/vtex.store-drawer.css
@@ -2,12 +2,17 @@
     display       : flex;
     flex-direction: row;
     align-items   : center;
-    transform     : translate(-419px, 10px);
-}
+/*     transform     : translate(-419px, 10px);
+ */}
 
 .opened--header__plp--filters {
     height   : 27rem;
     width    : 80rem;
     width    : 100vw !important;
     max-width: 100vw !important;
+}
+
+.drawerTriggerContainer--global__text--search {
+    display: flex;
+    flex-direction: row;
 }


### PR DESCRIPTION
##feat: adds structure and styles to the plp in all views
|-->description: In this commit i'm adding the plp of my page, the search filters for the products and the options for display in grid and list
|--> How to test it?: in the search bar, type one of the following categories: appliances or cheese and view the different options offered by the page with its filters:
https://mango--itgloberspartnercl.myvtex.com/